### PR TITLE
Initialize 'rq' before use

### DIFF
--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -5037,6 +5037,8 @@ static void nohz_idle_balance(int this_cpu, enum cpu_idle_type idle)
 		if (need_resched())
 			break;
 
+		rq = cpu_rq(balance_cpu);
+
 		/*
 		 * If time for next balance is due,
 		 * do the balance.
@@ -5049,7 +5051,6 @@ static void nohz_idle_balance(int this_cpu, enum cpu_idle_type idle)
 			rebalance_domains(balance_cpu, CPU_IDLE);
 		}
 
-		rq = cpu_rq(balance_cpu);
 		if (time_after(this_rq->next_balance, rq->next_balance))
 			this_rq->next_balance = rq->next_balance;
 	}


### PR DESCRIPTION
Resolves the error:
_kernel/sched/fair.c: In function 'run_rebalance_domains':
kernel/sched/fair.c:5044:32: warning: 'rq' may be used uninitialized in this function [-Wmaybe-uninitialized]
error, forbidden warning: fair.c:5044_
